### PR TITLE
JSDoc type annotation at `LaneModifyPacketData` incorrect (#54)

### DIFF
--- a/src_web/static/packet/lane_modify.js
+++ b/src_web/static/packet/lane_modify.js
@@ -58,7 +58,7 @@ export function encode_lane_modify_packet(channel, value) {
  *
  * @typedef {Object} LaneModifyPacketData
  * @property {number} channel Modified channel
- * @property {boolean} value Value
+ * @property {number} value Value
  */
 
 /**


### PR DESCRIPTION
Close #54

## Checks

- [x] Build or lint has passed
